### PR TITLE
fix: Add docs for custom_token_cache and update methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,7 @@ classifiers = [
 [tool.setuptools.packages.find]
 where = ["src"]
 exclude = ["tests/*"]
+
+[project.urls]
+Homepage = "https://github.com/csheader/fast-api-oidc"
+Issues = "https://github.com/csheader/fast-api-oidc/issues"

--- a/src/fast_api_jwt_middleware/auth/auth_middleware.py
+++ b/src/fast_api_jwt_middleware/auth/auth_middleware.py
@@ -83,7 +83,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
         self.audiences: List[str] = audiences
         self.excluded_paths = excluded_paths
         self.roles_key = roles_key
-        self.token_cache = custom_token_cache or TokenCacheSingleton.get_instance(
+        if custom_token_cache is not None:
+            TokenCacheSingleton.set_custom_cache(custom_token_cache)
+        self.token_cache = TokenCacheSingleton.get_instance(
             maxsize=token_cache_maxsize,
             ttl=token_ttl,
             logger=self.logger

--- a/src/fast_api_jwt_middleware/auth/multi_provider_auth_middleware.py
+++ b/src/fast_api_jwt_middleware/auth/multi_provider_auth_middleware.py
@@ -37,6 +37,7 @@ class MultiProviderAuthMiddleware(AuthMiddleware):
         token_ttl: int = 300,
         jwks_ttl: int = 3600,
         oidc_ttl: int = 3600,
+        custom_token_cache: Optional[CacheProtocol] = None,
         token_cache_maxsize: int = 1000,
         logger: Optional[LoggerProtocol] = None,
         excluded_paths: List[str] = [],
@@ -65,7 +66,7 @@ class MultiProviderAuthMiddleware(AuthMiddleware):
                          audiences=audiences, 
                          token_ttl=token_ttl, jwks_ttl=jwks_ttl, oidc_ttl=oidc_ttl,
                          token_cache_maxsize=token_cache_maxsize, logger=logger,
-                         excluded_paths=excluded_paths, roles_key=roles_key)
+                         excluded_paths=excluded_paths, roles_key=roles_key, custom_token_cache=custom_token_cache)
         self.providers = providers
 
     def get_provider_for_token(self, token: str) -> Optional[Dict]:

--- a/src/fast_api_jwt_middleware/cache/token_cache_singleton.py
+++ b/src/fast_api_jwt_middleware/cache/token_cache_singleton.py
@@ -1,3 +1,4 @@
+from fast_api_jwt_middleware.cache.cache_protocol_contract import CacheProtocol
 from fast_api_jwt_middleware.cache.token_cache import TokenCache
 from typing import Any, Optional
 
@@ -13,6 +14,12 @@ class TokenCacheSingleton:
         _instance (TokenCache): The singleton instance of the TokenCache.
     '''
     _instance = None
+    _custom_cache: CacheProtocol = None  # Just in case the caller wants to supply their own cache
+
+    @classmethod
+    def set_custom_cache(cls, custom_cache: CacheProtocol) -> None:
+        '''Set a custom cache instance.'''
+        cls._custom_cache = custom_cache
 
     @classmethod
     def get_instance(cls, maxsize=1000, ttl=300, logger=None):
@@ -23,6 +30,8 @@ class TokenCacheSingleton:
         :param ttl: Time-to-live for cached tokens in seconds.
         :return: The singleton instance of TokenCache.
         '''
+        if cls._custom_cache is not None:
+            return cls._custom_cache
         if cls._instance is None:
             cls._instance = TokenCache(maxsize=maxsize, ttl=ttl, logger=logger)
         return cls._instance
@@ -30,26 +39,38 @@ class TokenCacheSingleton:
     @classmethod
     def add_token(cls, token: str, value: Any) -> None:
         '''Add a token to the cache.'''
-        cls.get_instance().add_token(token, value)
+        if cls._custom_cache:
+            cls._custom_cache.add_token(token, value)
+        else:
+            cls.get_instance().add_token(token, value)
 
     @classmethod
     def get_token(cls, token: str) -> Optional[Any]:
         '''Retrieve a token from the cache.'''
+        if cls._custom_cache:
+            return cls._custom_cache.get_token(token)
         return cls.get_instance().get_token(token)
 
     @classmethod
     def remove_token(cls, token: str) -> bool:
         '''Remove a token from the cache.'''
+        if cls._custom_cache:
+            return cls._custom_cache.remove_token(token)
         return cls.get_instance().remove_token(token)
 
     @classmethod
     def clear(cls) -> None:
         '''Clear all tokens from the cache.'''
-        cls.get_instance().clear()
+        if cls._custom_cache:
+            cls._custom_cache.clear()
+        else:
+            cls.get_instance().clear()
 
     @classmethod
     def list_tokens(cls, page: int = 1, page_size: int = 10) -> dict:
         '''
         list tokens from the cache, only necessary in debugging scenarios
         '''
-        return cls.list_tokens(page, page_size)
+        if cls._custom_cache:
+            return cls._custom_cache.list_tokens(page, page_size)
+        return cls.get_instance().list_tokens(page, page_size)


### PR DESCRIPTION
Provide a way to inject your own cache for both single and multi provider auth. Update readme to explain how this works.
Add logger and cache protocol in the readme.