### PR TITLE
update tests so they run without errors

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,30 @@
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
+from tests import test_auth_middleware
+from tests import test_multi_provider_auth_middleware
+from tests import test_oidc_helper
+from tests import test_oidc_providers
+from tests import test_wrapper
+from tests import test_token_cache
+from tests import test_token_cache_singleton
+
+loader = unittest.TestLoader()
+suite = unittest.TestSuite()
+
+# Order the tests so that the cache_singleton tests happen
+# without impacting the token_cache tests. 
+suite.addTests(loader.loadTestsFromModule(test_token_cache_singleton))
+suite.addTests(loader.loadTestsFromModule(test_auth_middleware))
+suite.addTests(loader.loadTestsFromModule(test_multi_provider_auth_middleware))
+suite.addTests(loader.loadTestsFromModule(test_oidc_helper))
+suite.addTests(loader.loadTestsFromModule(test_oidc_providers))
+suite.addTests(loader.loadTestsFromModule(test_wrapper))
+suite.addTests(loader.loadTestsFromModule(test_token_cache))
+
+runner = unittest.TextTestRunner(verbosity=2)
+result = runner.run(suite)

--- a/tests/test_token_cache_singleton.py
+++ b/tests/test_token_cache_singleton.py
@@ -52,4 +52,16 @@ class TestTokenCacheSingleton(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    loader = unittest.TestLoader()
+    loader.sortTestMethodsUsing = None
+    # Order the tests in this file so that they do not impact
+    # eachother since this class is a singleton
+    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_singleton_instance)
+    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_add_token)
+    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_get_token_not_found)
+    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_remove_token)
+    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_remove_token_not_found)
+    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_remove_all)
+    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_clear_cache)
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite)


### PR DESCRIPTION
There is a race condition in the execution of tests if the token_cache and token_cache_singleton occur at the same time. To avoid this I put the token_cache_singleton tests at the beginning of the test runs and the token_cache tests at the end of the test runs. This is only an issue when running from the CLI, not from the built in test runners.