### PR TITLE
feat: Add support for token delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,30 @@ async def secure_endpoint_no_options():
 
 ```
 
+### Using `value_delimiter` in `secure_route`
+
+The `secure_route` decorator also supports a `value_delimiter` option, which allows you to specify a delimiter used to separate roles in the user roles string. This is useful when roles are stored as a single string with a specific delimiter.
+
+Example:
+
+from fast_api_jwt_middleware import secure_route
+
+```python
+# secured endpoint, uses a whitespace delimiter for roles
+@app.get("/secure-endpoint-whitespace-delimiter")
+@secure_route(required_roles="admin", roles_key='scp', value_delimiter=' ')
+async def secure_endpoint_whitespace_delimiter():
+    return {"message": "You have access to this secure endpoint."}
+
+# secured endpoint, uses a comma delimiter for roles
+@app.get("/secure-endpoint-comma-delimiter")
+@secure_route(required_roles="admin", roles_key='scp', value_delimiter=',')
+async def secure_endpoint_comma_delimiter():
+    return {"message": "You have access to this secure endpoint."}
+```
+
+In the above examples, the `value_delimiter` parameter is used to split the roles string into a list of roles. This allows the `secure_route` decorator to correctly check if the user has the required roles to access the endpoint.
+
 ### Accessing Token Properties
 
 This library also will add the token properties to the request.state in fast api as a part of the authentication process. If you need to access specific information off of your token you will need to understand your token's structure. By defauls all claims from the token are added as properties to the user object on the state property. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fast-api-jwt-middleware"
-version = "0.0.4"
+version = "1.0.0"
 description = "A FastAPI middleware for JWT-based authentication with support for multiple providers."
 readme = { file = "README.md", content-type = "text/markdown" } 
 license = { file = "LICENSE" }
@@ -21,7 +21,7 @@ dependencies = [
     "cryptography"
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fast-api-jwt-middleware"
-version = "1.0.0"
+version = "1.0.1"
 description = "A FastAPI middleware for JWT-based authentication with support for multiple providers."
 readme = { file = "README.md", content-type = "text/markdown" } 
 license = { file = "LICENSE" }

--- a/src/fast_api_jwt_middleware/cache/token_cache.py
+++ b/src/fast_api_jwt_middleware/cache/token_cache.py
@@ -70,7 +70,7 @@ class TokenCache:
         '''
         Clear all tokens from the cache.
         '''
-        self._cache.clear()
+        self._cache = TTLCache(maxsize=self._cache.maxsize, ttl=self._cache.ttl)
         self.logger.debug('All tokens cleared from cache.')
 
     def list_tokens(self, page: int = 1, page_size: int = 10) -> dict:

--- a/tests/test_token_cache_singleton.py
+++ b/tests/test_token_cache_singleton.py
@@ -11,6 +11,12 @@ class TestTokenCacheSingleton(unittest.TestCase):
         """Set up a TokenCacheSingleton instance for testing."""
         self.cache_singleton = TokenCacheSingleton()
 
+    def tearDown(self):
+        """Clear the TokenCacheSingleton instance after each test."""
+        TokenCacheSingleton.clear()
+        TokenCacheSingleton._instance = None
+        TokenCacheSingleton._custom_cache = None
+
     def test_singleton_instance(self):
         """Test that TokenCacheSingleton returns the same instance."""
         another_instance = TokenCacheSingleton()
@@ -18,8 +24,8 @@ class TestTokenCacheSingleton(unittest.TestCase):
 
     def test_add_token(self):
         """Test adding a token to the cache."""
-        self.cache_singleton.add_token("token1", {"user": "test_user"})
-        self.assertEqual(self.cache_singleton.get_token("token1"), {"user": "test_user"})
+        self.cache_singleton.add_token("token-test-1", {"sub": "user1"})
+        self.assertEqual(self.cache_singleton.get_token("token-test-1"), {"sub": "user1"})
 
     def test_get_token_not_found(self):
         """Test retrieving a token that does not exist."""
@@ -56,12 +62,7 @@ if __name__ == "__main__":
     loader.sortTestMethodsUsing = None
     # Order the tests in this file so that they do not impact
     # eachother since this class is a singleton
-    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_singleton_instance)
-    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_add_token)
-    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_get_token_not_found)
-    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_remove_token)
-    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_remove_token_not_found)
-    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_remove_all)
-    suite = loader.loadTestsFromTestCase(TestTokenCacheSingleton.test_clear_cache)
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(TestTokenCacheSingleton))
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -124,5 +124,15 @@ class TestSecureRoute(unittest.TestCase):
         result = is_called_from_async_context(sync_sum, 3, 7)
         self.assertEqual(result, 10, "The result should be the sum of the two inputs.")
 
+    def test_do_role_check_with_whitespace_delimited_roles(self):
+        """Test do_role_check with a whitespace-delimited roles string."""
+        user = {"scp": "admin user editor"}
+        required_roles = ["admin", "editor"]
+        try:
+            do_role_check(user, required_roles, roles_key='scp', value_delimiter=' ')
+        except HTTPException as e:
+            self.fail(f"do_role_check raised HTTPException unexpectedly: {e}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds support for token delimiters for situations like a `scp` property on the token. The `scp` property is generally an array of strings separated by either whitespace or a comma. Additional examples of other properties that use delimiters are generally comma separated or colon delimited strings.